### PR TITLE
Add Endlees AI checkbox

### DIFF
--- a/src/vss-engine/src/client/summarization.py
+++ b/src/vss-engine/src/client/summarization.py
@@ -25,12 +25,13 @@ import pkg_resources
 import yaml
 from gradio_videotimeline import VideoTimeline
 
-from utils import MediaFileInfo
+from utils import MediaFileInfo, StreamSettingsCache
 
 STANDALONE_MODE = True
 pipeline_args = None
 logger: Logger = None
 appConfig = {}
+stream_settings_cache: StreamSettingsCache | None = None
 
 DEFAULT_CHUNK_SIZE = 0
 DEFAULT_VIA_TARGET_RESPONSE_TIME = 2 * 60  # in seconds
@@ -458,6 +459,7 @@ async def summarize(
     vlm_input_width=0,
     vlm_input_height=0,
     cv_pipeline_prompt="",
+    endlees_ai_enabled=False,
     enable_audio=False,
     enable_chat_history=True,
     graph_rag_prompt_yaml=None,
@@ -532,6 +534,11 @@ async def summarize(
         if cv_pipeline_prompt:
             req_json["cv_pipeline_prompt"] = cv_pipeline_prompt
         req_json["enable_audio"] = enable_audio
+
+        if stream_settings_cache and media_ids:
+            existing = stream_settings_cache.load_stream_settings(video_id=media_ids[0])
+            existing.update({"endlees_ai_enabled": endlees_ai_enabled})
+            stream_settings_cache.update_stream_settings(media_ids[0], existing)
 
         parsed_alerts = []
         accumulated_responses = []
@@ -788,6 +795,7 @@ async def chat_checkbox_selected(chat_checkbox):
     )
 
 
+
 async def video_changed(video, image_mode):
     if video:
         if image_mode:
@@ -860,10 +868,11 @@ def get_display_image(f, image_mode):
 
 
 def build_summarization(args, app_cfg, logger_):
-    global appConfig, logger, pipeline_args
+    global appConfig, logger, pipeline_args, stream_settings_cache
     appConfig = app_cfg
     logger = logger_
     pipeline_args = args
+    stream_settings_cache = StreamSettingsCache(logger=logger)
 
     (
         default_prompt,
@@ -990,6 +999,11 @@ def build_summarization(args, app_cfg, logger_):
                             and bool(
                                 os.environ.get("DISABLE_CV_PIPELINE", "true").lower() == "false"
                             ),
+                        )
+
+                        endlees_ai_checkbox = gr.Checkbox(
+                            value=False,
+                            label="Endlees AI Enabled",
                         )
 
                 with gr.Tab("Samples"):
@@ -1774,6 +1788,7 @@ def build_summarization(args, app_cfg, logger_):
             vlm_input_width,
             vlm_input_height,
             cv_pipeline_prompt,
+            endlees_ai_checkbox,
             enable_audio,
             chat_history_checkbox,
         ],

--- a/src/vss-engine/src/client/ui_utils.py
+++ b/src/vss-engine/src/client/ui_utils.py
@@ -254,6 +254,9 @@ class RetrieveCache:
                 value=id_settings.get("cv_pipeline_prompt", ""), interactive=True
             ),  # cv_pipeline_prompt
             gr.update(
+                value=id_settings.get("endlees_ai_enabled", False), interactive=True
+            ),  # endlees_ai_enabled
+            gr.update(
                 value=id_settings.get("enable_audio", False), interactive=True
             ),  # enable_audio
             gr.update(

--- a/src/vss-engine/src/utils.py
+++ b/src/vss-engine/src/utils.py
@@ -632,6 +632,7 @@ class StreamSettingsCache:
             "caption_summarization_prompt",
             "summary_aggregation_prompt",
             "cv_pipeline_prompt",
+            "endlees_ai_enabled",
             "tools",
         }
 

--- a/src/vss-engine/src/vlm_pipeline/video_file_frame_getter.py
+++ b/src/vss-engine/src/vlm_pipeline/video_file_frame_getter.py
@@ -208,6 +208,7 @@ class VideoFileFrameGetter:
         image_aspect_ratio="",
         data_type_int8=False,
         audio_support=False,
+        endlees_ai_enabled=False,
         cv_pipeline_configs={},
     ) -> None:
         self._selected_pts_array = []
@@ -232,6 +233,7 @@ class VideoFileFrameGetter:
         self._data_type_int8 = data_type_int8
         self._audio_support = audio_support
         self._enable_audio = False
+        self._endlees_ai_enabled = endlees_ai_enabled
         self._pipeline = None
         self._last_stream_id = ""
         self._is_live = False
@@ -339,6 +341,10 @@ class VideoFileFrameGetter:
             self._previous_frame_height = self._frame_height
             self._frame_height = frame_height
             self._destroy_pipeline = True
+
+    def set_endlees_ai_enabled(self, enabled: bool):
+        """Set Endlees AI flag."""
+        self._endlees_ai_enabled = enabled
 
     def _preprocess(self, frames):
         if frames and not self._enable_jpeg_output:
@@ -2991,6 +2997,7 @@ if __name__ == "__main__":
         frame_selector=DefaultFrameSelector(args.num_frames),
         enable_jpeg_output=args.enable_jpeg_output,
         audio_support=args.enable_audio,
+        endlees_ai_enabled=False,
     )
 
     if args.file_or_rtsp.startswith("rtsp://"):

--- a/src/vss-engine/src/vlm_pipeline/vlm_pipeline.py
+++ b/src/vss-engine/src/vlm_pipeline/vlm_pipeline.py
@@ -25,6 +25,8 @@ from enum import Enum
 from threading import Event, Lock, Thread
 from typing import Callable, Optional
 
+from utils import StreamSettingsCache
+
 import nvtx
 import riva.client
 import torch
@@ -315,6 +317,9 @@ class DecoderProcess(ViaProcessBase):
 
         if vlm_input_width or vlm_input_height:
             fgetter._set_frame_resolution(vlm_input_width, vlm_input_height)
+        cache = StreamSettingsCache(logger=logger)
+        settings = cache.load_stream_settings(chunk.streamId)
+        fgetter.set_endlees_ai_enabled(settings.get("endlees_ai_enabled", False))
         frames, frame_times, audio_frames = fgetter.get_frames(
             chunk, True, frame_selector, enable_audio, request_id=kwargs["request_id"]
         )
@@ -392,8 +397,12 @@ class DecoderProcess(ViaProcessBase):
             enable_jpeg_output=self._enable_jpeg_tensors,
             data_type_int8=self._data_type_int8,
             audio_support=self._enable_audio,
+            endlees_ai_enabled=False,
             cv_pipeline_configs=self._cv_pipeline_configs,
         )
+        cache = StreamSettingsCache(logger=logger)
+        settings = cache.load_stream_settings(live_stream_id)
+        fgetter.set_endlees_ai_enabled(settings.get("endlees_ai_enabled", False))
         if vlm_input_width or vlm_input_height:
             fgetter._set_frame_resolution(vlm_input_width, vlm_input_height)
 


### PR DESCRIPTION
## Summary
- persist Endlees AI checkbox setting in stream cache
- pass cached flag to `VideoFileFrameGetter`
- make cache accessible from summarization UI

## Testing
- `python -m py_compile src/vss-engine/src/client/summarization.py src/vss-engine/src/client/ui_utils.py src/vss-engine/src/utils.py src/vss-engine/src/vlm_pipeline/vlm_pipeline.py src/vss-engine/src/vlm_pipeline/video_file_frame_getter.py`

------
https://chatgpt.com/codex/tasks/task_b_6847de76a80c832db2d54eee1f3e5a0b