### PR TITLE
Rename endless AI flag

### DIFF
--- a/src/vss-engine/src/client/rtsp_stream.py
+++ b/src/vss-engine/src/client/rtsp_stream.py
@@ -478,7 +478,7 @@ async def add_rtsp_stream(
     enable_chat,
     enable_cv_metadata,
     cv_pipeline_prompt,
-    endlees_ai_enabled,
+    endless_ai_enabled,
     enable_audio,
     clear,
     enable_chat_history,
@@ -514,7 +514,7 @@ async def add_rtsp_stream(
 
             if stream_settings_cache and video_id:
                 existing = stream_settings_cache.load_stream_settings(video_id=video_id)
-                existing.update({"endlees_ai_enabled": endlees_ai_enabled})
+                existing.update({"endless_ai_enabled": endless_ai_enabled})
                 stream_settings_cache.update_stream_settings(video_id, existing)
 
             req_json = {
@@ -733,7 +733,7 @@ async def reconnect_live_stream(
     enable_chat,
     enable_cv_metadata,
     cv_pipeline_prompt,
-    endlees_ai_enabled,
+    endless_ai_enabled,
     enable_audio,
     clear,
     enable_chat_history,
@@ -753,7 +753,7 @@ async def reconnect_live_stream(
 
     if stream_settings_cache and video_id:
         existing = stream_settings_cache.load_stream_settings(video_id=video_id)
-        existing.update({"endlees_ai_enabled": endlees_ai_enabled})
+        existing.update({"endless_ai_enabled": endless_ai_enabled})
         stream_settings_cache.update_stream_settings(video_id, existing)
 
     req_json = {
@@ -1094,9 +1094,9 @@ def build_rtsp_stream(args, app_cfg, logger_):
                             ),
                         )
 
-                        endlees_ai_checkbox = gr.Checkbox(
+                        endless_ai_checkbox = gr.Checkbox(
                             value=False,
-                            label="Endlees AI Enabled",
+                            label="Endless AI Enabled",
                         )
 
                 with gr.Tab("Create Alerts"):
@@ -1720,7 +1720,7 @@ def build_rtsp_stream(args, app_cfg, logger_):
             rag_top_k,
             enable_cv_metadata,
             cv_pipeline_prompt,
-            endlees_ai_checkbox,
+            endless_ai_checkbox,
             enable_audio,
             alerts_table,
             table_state,
@@ -1781,7 +1781,7 @@ def build_rtsp_stream(args, app_cfg, logger_):
             enable_chat,
             enable_cv_metadata,
             cv_pipeline_prompt,
-            endlees_ai_checkbox,
+            endless_ai_checkbox,
             enable_audio,
             clear,
             enable_chat_history,
@@ -1829,7 +1829,7 @@ def build_rtsp_stream(args, app_cfg, logger_):
             reconnect_button,
             enable_cv_metadata,
             cv_pipeline_prompt,
-            endlees_ai_checkbox,
+            endless_ai_checkbox,
             enable_audio,
             live_stream_id_preview,
             clear,
@@ -1881,7 +1881,7 @@ def build_rtsp_stream(args, app_cfg, logger_):
             enable_chat,
             enable_cv_metadata,
             cv_pipeline_prompt,
-            endlees_ai_checkbox,
+            endless_ai_checkbox,
             enable_audio,
             clear,
             enable_chat_history,
@@ -1929,7 +1929,7 @@ def build_rtsp_stream(args, app_cfg, logger_):
             reconnect_button,
             enable_cv_metadata,
             cv_pipeline_prompt,
-            endlees_ai_checkbox,
+            endless_ai_checkbox,
             enable_audio,
             clear,
             live_stream_id_preview,

--- a/src/vss-engine/src/client/summarization.py
+++ b/src/vss-engine/src/client/summarization.py
@@ -459,7 +459,7 @@ async def summarize(
     vlm_input_width=0,
     vlm_input_height=0,
     cv_pipeline_prompt="",
-    endlees_ai_enabled=False,
+    endless_ai_enabled=False,
     enable_audio=False,
     enable_chat_history=True,
     graph_rag_prompt_yaml=None,
@@ -537,7 +537,7 @@ async def summarize(
 
         if stream_settings_cache and media_ids:
             existing = stream_settings_cache.load_stream_settings(video_id=media_ids[0])
-            existing.update({"endlees_ai_enabled": endlees_ai_enabled})
+            existing.update({"endless_ai_enabled": endless_ai_enabled})
             stream_settings_cache.update_stream_settings(media_ids[0], existing)
 
         parsed_alerts = []
@@ -1001,9 +1001,9 @@ def build_summarization(args, app_cfg, logger_):
                             ),
                         )
 
-                        endlees_ai_checkbox = gr.Checkbox(
+                        endless_ai_checkbox = gr.Checkbox(
                             value=False,
-                            label="Endlees AI Enabled",
+                            label="Endless AI Enabled",
                             visible=not args.image_mode,
                         )
 
@@ -1789,7 +1789,7 @@ def build_summarization(args, app_cfg, logger_):
             vlm_input_width,
             vlm_input_height,
             cv_pipeline_prompt,
-            endlees_ai_checkbox,
+            endless_ai_checkbox,
             enable_audio,
             chat_history_checkbox,
         ],

--- a/src/vss-engine/src/client/ui_utils.py
+++ b/src/vss-engine/src/client/ui_utils.py
@@ -254,8 +254,8 @@ class RetrieveCache:
                 value=id_settings.get("cv_pipeline_prompt", ""), interactive=True
             ),  # cv_pipeline_prompt
             gr.update(
-                value=id_settings.get("endlees_ai_enabled", False), interactive=True
-            ),  # endlees_ai_enabled
+                value=id_settings.get("endless_ai_enabled", False), interactive=True
+            ),  # endless_ai_enabled
             gr.update(
                 value=id_settings.get("enable_audio", False), interactive=True
             ),  # enable_audio

--- a/src/vss-engine/src/utils.py
+++ b/src/vss-engine/src/utils.py
@@ -632,7 +632,7 @@ class StreamSettingsCache:
             "caption_summarization_prompt",
             "summary_aggregation_prompt",
             "cv_pipeline_prompt",
-            "endlees_ai_enabled",
+            "endless_ai_enabled",
             "tools",
         }
 

--- a/src/vss-engine/src/vlm_pipeline/video_file_frame_getter.py
+++ b/src/vss-engine/src/vlm_pipeline/video_file_frame_getter.py
@@ -208,7 +208,7 @@ class VideoFileFrameGetter:
         image_aspect_ratio="",
         data_type_int8=False,
         audio_support=False,
-        endlees_ai_enabled=False,
+        endless_ai_enabled=False,
         cv_pipeline_configs={},
     ) -> None:
         self._selected_pts_array = []
@@ -233,7 +233,7 @@ class VideoFileFrameGetter:
         self._data_type_int8 = data_type_int8
         self._audio_support = audio_support
         self._enable_audio = False
-        self._endlees_ai_enabled = endlees_ai_enabled
+        self._endless_ai_enabled = endless_ai_enabled
         self._pipeline = None
         self._last_stream_id = ""
         self._is_live = False
@@ -342,9 +342,9 @@ class VideoFileFrameGetter:
             self._frame_height = frame_height
             self._destroy_pipeline = True
 
-    def set_endlees_ai_enabled(self, enabled: bool):
-        """Set Endlees AI flag."""
-        self._endlees_ai_enabled = enabled
+    def set_endless_ai_enabled(self, enabled: bool):
+        """Set Endless AI flag."""
+        self._endless_ai_enabled = enabled
 
     def _preprocess(self, frames):
         if frames and not self._enable_jpeg_output:
@@ -2997,7 +2997,7 @@ if __name__ == "__main__":
         frame_selector=DefaultFrameSelector(args.num_frames),
         enable_jpeg_output=args.enable_jpeg_output,
         audio_support=args.enable_audio,
-        endlees_ai_enabled=False,
+        endless_ai_enabled=False,
     )
 
     if args.file_or_rtsp.startswith("rtsp://"):

--- a/src/vss-engine/src/vlm_pipeline/vlm_pipeline.py
+++ b/src/vss-engine/src/vlm_pipeline/vlm_pipeline.py
@@ -319,7 +319,7 @@ class DecoderProcess(ViaProcessBase):
             fgetter._set_frame_resolution(vlm_input_width, vlm_input_height)
         cache = StreamSettingsCache(logger=logger)
         settings = cache.load_stream_settings(chunk.streamId)
-        fgetter.set_endlees_ai_enabled(settings.get("endlees_ai_enabled", False))
+        fgetter.set_endless_ai_enabled(settings.get("endless_ai_enabled", False))
         frames, frame_times, audio_frames = fgetter.get_frames(
             chunk, True, frame_selector, enable_audio, request_id=kwargs["request_id"]
         )
@@ -397,12 +397,12 @@ class DecoderProcess(ViaProcessBase):
             enable_jpeg_output=self._enable_jpeg_tensors,
             data_type_int8=self._data_type_int8,
             audio_support=self._enable_audio,
-            endlees_ai_enabled=False,
+            endless_ai_enabled=False,
             cv_pipeline_configs=self._cv_pipeline_configs,
         )
         cache = StreamSettingsCache(logger=logger)
         settings = cache.load_stream_settings(live_stream_id)
-        fgetter.set_endlees_ai_enabled(settings.get("endlees_ai_enabled", False))
+        fgetter.set_endless_ai_enabled(settings.get("endless_ai_enabled", False))
         if vlm_input_width or vlm_input_height:
             fgetter._set_frame_resolution(vlm_input_width, vlm_input_height)
 


### PR DESCRIPTION
## Summary
- rename `endlees_ai_enabled` -> `endless_ai_enabled`
- propagate rename across UI, cache, and pipelines

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6849933fe8f0832db27338d4be77f944